### PR TITLE
possibility to make parent resource optional

### DIFF
--- a/lib/api_notify/active_record/main.rb
+++ b/lib/api_notify/active_record/main.rb
@@ -204,7 +204,14 @@ module ApiNotify
       def all_indentificators?(endpoint)
         return false unless parent_api_notified_or_notify_it?(endpoint)
         return true unless method_exists? "#{endpoint}_parent_attribute"
-        return get_identificators(endpoint)[self.class.send("#{endpoint}_parent_attribute")].present?
+
+        if get_identificators(endpoint)[self.class.send("#{endpoint}_parent_attribute")].present?
+          true
+        elsif respond_to? "#{endpoint}_parent_sync_optional?"
+          send "#{endpoint}_parent_sync_optional?"
+        else
+          false
+        end
       end
 
       #


### PR DESCRIPTION
Allows to define a method on model to allow skipping sending the parent resource.