### PR TITLE
lock 'rufus-scheduler' on '3.2.1' version because of error 'compariso…

### DIFF
--- a/api_notify.gemspec
+++ b/api_notify.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "sidekiq"
   s.add_dependency "sidekiq-cron"
+  s.add_dependency "rufus-scheduler", '3.2.1'
   s.add_development_dependency "rails"
   s.add_development_dependency "fakeredis"
   s.add_development_dependency "rspec-sidekiq"


### PR DESCRIPTION
…n of Time with EtOrbi::EoTime failed'